### PR TITLE
Feature overloaded minus

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,21 +4,24 @@ from evaluator_ import Evaluator
 
 # Input your expression here!
 
-s = "   ~123/ (11 + 32 / 23) + ((11/237+(169-36))*42) - ~92     "
-# s =  "(2+3*2)+((~2*5+8)*1)"
+# s = " (11 + 32 / -(-23+1))+ (-(11/237+(169-36))*42) - -92     "
+# s = "-(-1)"
+s =  "(2+3*2)+((-2*5+8)*1)"
 
 parser = Parser(s)
 ast = parser.get_ast()
-interpreter = Evaluator(ast)
+print(ast)
 
 if bool(ast):
     # print(infix_to_prefix(s))
     print(to_prefix(ast))
     # print(infix_to_postfix(s))
     print(to_postfix(ast))
+
+    interpreter = Evaluator(ast)
     print(interpreter.eval())
 
 else:
     print("Invalid Expression")
 
-# print(eval(str(ast)))
+print(eval(str(s)))

--- a/main.py
+++ b/main.py
@@ -2,26 +2,31 @@ from parser_ import Parser
 from syntax_converter import *
 from evaluator_ import Evaluator
 
-# Input your expression here!
 
-# s = " (11 + 32 / -(-23+1))+ (-(11/237+(169-36))*42) - -92     "
-# s = "-(-1)"
-s =  "(2+3*2)+((-2*5+8)*1)"
+def main():
+    # Input your expression here!
 
-parser = Parser(s)
-ast = parser.get_ast()
-print(ast)
+    # s = " (11 + 32 / -(-23+1))+ (-(11/237+(169-36))*42) - -92     "
+    # s = "-(-1)"
+    s =  "(2+3*2)+((-2*5+8)*1)"
 
-if bool(ast):
-    # print(infix_to_prefix(s))
-    print(to_prefix(ast))
-    # print(infix_to_postfix(s))
-    print(to_postfix(ast))
+    parser = Parser(s)
+    ast = parser.get_ast()
+    print(ast)
 
-    interpreter = Evaluator(ast)
-    print(interpreter.eval())
+    if bool(ast):
+        # print(infix_to_prefix(s))
+        print(to_prefix(ast))
+        # print(infix_to_postfix(s))
+        print(to_postfix(ast))
 
-else:
-    print("Invalid Expression")
+        interpreter = Evaluator(ast)
+        print(interpreter.eval())
 
-print(eval(str(s)))
+    else:
+        print("Invalid Expression")
+
+    print(eval(str(s)))
+
+if __name__ == "__main__":
+    main()

--- a/tokenizer_.py
+++ b/tokenizer_.py
@@ -28,7 +28,7 @@ class Tokenizer:
             return self.get_next_token()
         if STRING[0].isdecimal():
             number = ""
-            for char in STRING: #? maybe check if there is a next token
+            for char in STRING:
                 if not char.isdecimal():
                     break
                 number += char
@@ -37,9 +37,14 @@ class Tokenizer:
         if STRING[0] == "~":
             self.cursor += 1
             return Token("NEGATE", STRING[0])   
-        if self.is_minus(STRING[0]):
+        if self.is_minus(STRING[0]): # overloaded '-' symbol
             minus = STRING[0]
+            idx_prev_char = self.cursor - 1
             self.cursor += 1
+            while idx_prev_char > 0 and self.s[idx_prev_char].isspace(): # check last character to get context of '-' symbol
+                idx_prev_char -= 1
+            if self.is_unary_negation(idx_prev_char):
+                return Token("NEGATE", minus)
             return Token("MINUS", minus)
         if self.is_plus(STRING[0]):
             plus = STRING[0]
@@ -64,14 +69,15 @@ class Tokenizer:
         else:
             raise SyntaxError(f"Invalid Token: '{STRING[0]}'")
 
-    def has_more_tokens(self):
-        return self.cursor < len(self.s)
-
     """
     Helper Functions
     """
-    def is_digit(self, s):
-        return s == '0' or s == '1' or s == '2' or s == '3'
+    def has_more_tokens(self):
+        return self.cursor < len(self.s)
+
+    def is_unary_negation(self, idx): # if the character is the first character or if previous non-space character is an operation or opening parenthesis, the '-' must represent unary negation
+        return idx <= 0 or self.s[idx] in "+-*/(" 
+
     def is_plus(self, s):
         return s == "+"
     def is_minus(self, s):

--- a/tokenizer_.py
+++ b/tokenizer_.py
@@ -33,10 +33,7 @@ class Tokenizer:
                     break
                 number += char
                 self.cursor += 1
-            return Token("DIGIT", number)
-        if STRING[0] == "~":
-            self.cursor += 1
-            return Token("NEGATE", STRING[0])   
+            return Token("DIGIT", number)   
         if self.is_minus(STRING[0]): # overloaded '-' symbol
             minus = STRING[0]
             idx_prev_char = self.cursor - 1

--- a/tree_.py
+++ b/tree_.py
@@ -47,12 +47,6 @@ class BinaryOpNode(Node):
     def __str__(self) -> str:
         return f"({self.num1} {self.op.value} {self.num2})"
 
-
-class UnaryOpNode(Node):
-    def __init__(self, op_token, num_token) -> None:
-        super().__init__(op_token, num_token)
-        self.op = self.value
-        
 """
 Generic Binary Tree Data Structure
 """

--- a/tree_.py
+++ b/tree_.py
@@ -47,6 +47,12 @@ class BinaryOpNode(Node):
     def __str__(self) -> str:
         return f"({self.num1} {self.op.value} {self.num2})"
 
+
+class UnaryOpNode(Node):
+    def __init__(self, op_token, num_token) -> None:
+        super().__init__(op_token, num_token)
+        self.op = self.value
+        
 """
 Generic Binary Tree Data Structure
 """


### PR DESCRIPTION
- the '-' symbol can be a unary negation token or a binary subtraction token.
- the '~' symbol will no longer be accepted as a valid input
- added logic to the parser to allow the unary negation of digits and expressions
    - unary negation for digits are directly represented as a `NumberNode` value
    - unary negation for expressions are converted to a  `BinaryOpNode`: -(1+2) => (0-(1+2))